### PR TITLE
Fix for ignored "filepattern" parameter.

### DIFF
--- a/manifests/appenders/rollingfile.pp
+++ b/manifests/appenders/rollingfile.pp
@@ -74,6 +74,7 @@ define log4j::appenders::rollingfile(
     "set Configuration/Appenders/RollingFile[./#attribute/name = '${name}']/#attribute/bufferedIO ${bufferedio}",
     "set Configuration/Appenders/RollingFile[./#attribute/name = '${name}']/#attribute/bufferSize ${buffersize}",
     "set Configuration/Appenders/RollingFile[./#attribute/name = '${name}']/#attribute/fileName '${filename}'",
+    "set Configuration/Appenders/RollingFile[./#attribute/name = '${name}']/#attribute/filePattern '${filepattern}'",
     "set Configuration/Appenders/RollingFile[./#attribute/name = '${name}']/#attribute/immediateFlush ${immediateflush}",
     "set Configuration/Appenders/RollingFile[./#attribute/name = '${name}']/#attribute/ignoreExceptions ${ignoreexceptions}",
     "set Configuration/Appenders/RollingFile[./#attribute/name = '${name}']/DefaultRolloverStrategy/#attribute/fileIndex ${strategy_fileindex}",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "danielgil-log4j",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": "Daniel Gil",
   "license": "Apache-2.0",
   "summary": "Manages log4j configuration files",


### PR DESCRIPTION
It looks the "filepattern" parameter was being ignored which caused log4j2 to fail to initialize.